### PR TITLE
Add Changelog for 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.1.0 (released 2015-08-07)
+
+- Initial testing release


### PR DESCRIPTION
Please release this first testing version `0.1.0`. When this release is tagged we can start testing this is real environments and don't have to rely on `dev-master` to be stable.