### PR TITLE
+ is treated as space in query sting

### DIFF
--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -33,8 +33,8 @@ class Criteria
         foreach ($fields as $field) {
             $order = substr($field, 0, 1);
 
-            if ($order === '+' || $order === '-') {
-                $sort[substr($field, 1)] = $order === '+' ? 'asc' : 'desc';
+            if ($order === '+' || $order === '-' || $order === ' ') {
+                $sort[substr($field, 1)] = $order === '+' || $order === ' ' ? 'asc' : 'desc';
             }
         }
 


### PR DESCRIPTION
`+` is treated as ` ` ( space ) in query sting.

So when doing `/?sort=+foo,-bar` the result we get is 

```
"bar": "desc"
````
 Also created this little video if you like to check http://cl.ly/c1QT