### PR TITLE
Rename abstract classes

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -19,7 +19,7 @@ use Tobscure\JsonApi\Elements\Collection;
  *
  * @author Toby Zerner <toby.zerner@gmail.com>
  */
-abstract class SerializerAbstract implements SerializerInterface
+abstract class AbstractSerializer implements SerializerInterface
 {
     /**
      * @var string
@@ -148,6 +148,11 @@ abstract class SerializerAbstract implements SerializerInterface
         return new Resource($this->type, $this->getId($data), $this->getAttributes($data), $links, $included);
     }
 
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
     protected function getRelationshipFromMethod($name)
     {
         if (method_exists($this, $name)) {

--- a/src/Elements/AbstractElement.php
+++ b/src/Elements/AbstractElement.php
@@ -16,7 +16,7 @@ namespace Tobscure\JsonApi\Elements;
  *
  * @author Toby Zerner <toby.zerner@gmail.com>
  */
-abstract class ElementAbstract implements ElementInterface
+abstract class AbstractElement implements ElementInterface
 {
     protected $type;
 

--- a/src/Elements/Collection.php
+++ b/src/Elements/Collection.php
@@ -16,7 +16,7 @@ namespace Tobscure\JsonApi\Elements;
  *
  * @author Toby Zerner <toby.zerner@gmail.com>
  */
-class Collection extends ElementAbstract
+class Collection extends AbstractElement
 {
     protected $resources;
 

--- a/src/Elements/Resource.php
+++ b/src/Elements/Resource.php
@@ -16,7 +16,7 @@ namespace Tobscure\JsonApi\Elements;
  *
  * @author Toby Zerner <toby.zerner@gmail.com>
  */
-class Resource extends ElementAbstract
+class Resource extends AbstractElement
 {
     protected $id;
 


### PR DESCRIPTION
The reason behind this is to follow the [PHP FIG naming conventions](https://github.com/php-fig/fig-standards/blob/master/bylaws/002-psr-naming-conventions.md).