### PR TITLE
Fixed phpdoc

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -165,11 +165,13 @@ abstract class AbstractSerializer implements SerializerInterface
     }
 
     /**
-     * Given a flat array of relationship paths like:.
+     * Parse relationship paths.
+     * 
+     * Given a flat array of relationship paths like:
      *
      *     ['user', 'user.employer', 'user.employer.country', 'comments']
      *
-     * ... create a nested array of relationship paths one-level deep that can
+     * create a nested array of relationship paths one-level deep that can
      * be passed on to other serializers:
      *
      *     ['user' => ['employer', 'employer.country'], 'comments' => []]


### PR DESCRIPTION
Before, your short description was:

```markdown
Given a flat array of relationship paths like:.
```

and your long description was:

```markdown

    ['user', 'user.employer', 'user.employer.country', 'comments']

... create a nested array of relationship paths one-level deep that can
be passed on to other serializers:

    ['user' => ['employer', 'employer.country'], 'comments' => []]
```

As far as I can see, that made no sense at all.

Now your short description is:

```markdown
Parse relationship paths.
```

And your long description is:

```markdown
Given a flat array of relationship paths like:

    ['user', 'user.employer', 'user.employer.country', 'comments']

create a nested array of relationship paths one-level deep that can
be passed on to other serializers:

    ['user' => ['employer', 'employer.country'], 'comments' => []]
```