### PR TITLE
PHP 5.3.* compliance

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -48,7 +48,7 @@ abstract class AbstractSerializer implements SerializerInterface
      * @param array $include
      * @param array $link
      */
-    public function __construct(array $include = [], array $link = [])
+    public function __construct(array $include = array(), array $link = array())
     {
         $this->include = $include;
         $this->link = $link;
@@ -108,7 +108,7 @@ abstract class AbstractSerializer implements SerializerInterface
             return;
         }
 
-        $resources = [];
+        $resources = array();
 
         foreach ($data as $record) {
             $resources[] = $this->resource($record);
@@ -134,14 +134,14 @@ abstract class AbstractSerializer implements SerializerInterface
             return new Resource($this->type, $data);
         }
 
-        $included = $links = [];
+        $included = $links = array();
 
-        $relationships = [
+        $relationships = array(
             'link' => $this->parseRelationshipPaths($this->link),
             'include' => $this->parseRelationshipPaths($this->include),
-        ];
+        );
 
-        foreach (['link', 'include'] as $type) {
+        foreach (array('link', 'include') as $type) {
             $include = $type === 'include';
 
             foreach ($relationships[$type] as $name => $nested) {
@@ -151,8 +151,8 @@ abstract class AbstractSerializer implements SerializerInterface
                     $element = $method(
                         $data,
                         $include,
-                        isset($relationships['include'][$name]) ? $relationships['include'][$name] : [],
-                        isset($relationships['link'][$name]) ? $relationships['link'][$name] : []
+                        isset($relationships['include'][$name]) ? $relationships['include'][$name] : array(),
+                        isset($relationships['link'][$name]) ? $relationships['link'][$name] : array()
                     );
                 }
 
@@ -204,13 +204,13 @@ abstract class AbstractSerializer implements SerializerInterface
      */
     protected function parseRelationshipPaths(array $paths)
     {
-        $tree = [];
+        $tree = array();
 
         foreach ($paths as $path) {
             list($primary, $nested) = array_pad(explode('.', $path, 2), 2, null);
 
             if (!isset($tree[$primary])) {
-                $tree[$primary] = [];
+                $tree[$primary] = array();
             }
 
             if ($nested) {

--- a/src/Document.php
+++ b/src/Document.php
@@ -32,7 +32,7 @@ class Document implements JsonSerializable
      *
      * @var array
      */
-    protected $included = [];
+    protected $included = array();
 
     /**
      * The meta data array.
@@ -69,7 +69,7 @@ class Document implements JsonSerializable
         foreach ($resources as $k => $resource) {
             // If the resource doesn't have any attributes, then we don't need to
             // put it into the included part of the document.
-            if (!$resource->getAttributes()) {
+            if (! $resource->getAttributes()) {
                 unset($resources[$k]);
             } else {
                 foreach ($resource->getIncluded() as $link) {
@@ -80,8 +80,7 @@ class Document implements JsonSerializable
 
         foreach ($resources as $k => $resource) {
             foreach ($this->included as $includedResource) {
-                if ($includedResource->getType() === $resource->getType()
-                    && $includedResource->getId() === $resource->getId()) {
+                if ($includedResource->getType() === $resource->getType() && $includedResource->getId() === $resource->getId()) {
                     $includedResource->merge($resource);
                     unset($resources[$k]);
                     break;
@@ -183,29 +182,29 @@ class Document implements JsonSerializable
      */
     public function toArray()
     {
-        $document = [];
+        $document = array();
 
-        if (!empty($this->links)) {
+        if (! empty($this->links)) {
             ksort($this->links);
             $document['links'] = $this->links;
         }
 
-        if (!empty($this->data)) {
+        if (! empty($this->data)) {
             $document['data'] = $this->data->toArray();
         }
 
-        if (!empty($this->included)) {
-            $document['included'] = [];
+        if (! empty($this->included)) {
+            $document['included'] = array();
             foreach ($this->included as $resource) {
                 $document['included'][] = $resource->toArray();
             }
         }
 
-        if (!empty($this->meta)) {
+        if (! empty($this->meta)) {
             $document['meta'] = $this->meta;
         }
 
-        if (!empty($this->errors)) {
+        if (! empty($this->errors)) {
             $document['errors'] = $this->errors;
         }
 

--- a/src/Elements/Collection.php
+++ b/src/Elements/Collection.php
@@ -44,7 +44,7 @@ class Collection extends AbstractElement
      */
     public function getId()
     {
-        $ids = [];
+        $ids = array();
 
         foreach ($this->resources as $resource) {
             $ids[] = $resource->getId();

--- a/src/Elements/Resource.php
+++ b/src/Elements/Resource.php
@@ -30,21 +30,21 @@ class Resource extends AbstractElement
      *
      * @var array
      */
-    protected $attributes = [];
+    protected $attributes = array();
 
     /**
      * The links array.
      *
      * @var array
      */
-    protected $links = [];
+    protected $links = array();
 
     /**
      * The included array.
      *
      * @var array
      */
-    protected $included = [];
+    protected $included = array();
 
     /**
      * Create a new resource instance.
@@ -55,7 +55,7 @@ class Resource extends AbstractElement
      * @param array $links
      * @param array $included
      */
-    public function __construct($type, $id, $attributes = [], $links = [], $included = [])
+    public function __construct($type, $id, $attributes = array(), $links = array(), $included = array())
     {
         $this->type = $type;
         $this->attributes = $attributes;
@@ -184,7 +184,7 @@ class Resource extends AbstractElement
      */
     public function getResources()
     {
-        return [$this];
+        return array($this);
     }
 
     /**
@@ -210,13 +210,13 @@ class Resource extends AbstractElement
      */
     public function toArray($full = true)
     {
-        $array = ['type' => $this->type, 'id' => $this->id];
+        $array = array('type' => $this->type, 'id' => $this->id);
 
         if ($full) {
             $array['attributes'] = (array) $this->attributes;
 
             if ($this->links || $this->included) {
-                $array['relationships'] = [];
+                $array['relationships'] = array();
 
                 foreach ($this->included as $name => $relationship) {
                     $array['relationships'][$name] = $relationship->toArray();

--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -146,21 +146,21 @@ class Relationship
      */
     public function toArray()
     {
-        $link = [];
+        $link = array();
 
-        if (!empty($this->data)) {
+        if (! empty($this->data)) {
             $link['data'] = $this->data->toArray(false);
         }
 
-        if (!empty($this->self)) {
+        if (! empty($this->self)) {
             $link['self'] = $this->self;
         }
 
-        if (!empty($this->related)) {
+        if (! empty($this->related)) {
             $link['related'] = $this->related;
         }
 
-        if (!empty($this->meta)) {
+        if (! empty($this->meta)) {
             $link['meta'] = $this->meta;
         }
 


### PR DESCRIPTION
Hi guys,
our production server here runs on PHP 5.3.17 so we ran into some issues when parsing instructions like

  $var = [];

Consequently, we substituted all those occurences with

  $var = array();

which is a little less fancy but enabled us to enjoy the goodness of this great library.

It would be great for us if  this PR was merged since we don't like our version to diverge from the main one, but we would understand if you're not interested to be compliant with an old version of PHP.

Btw the tests are OK and no API changes are introduced.