### PR TITLE
Fixed error regarding `fields` param

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -139,7 +139,7 @@ class Parameters
      */
     public function getFields()
     {
-        $fields = $this->getInput('fields');
+        $fields = $this->getInput('fields', []);
 
         return array_map(function ($fields) {
             return explode(',', $fields);


### PR DESCRIPTION
This is a (short) fix, for the issue described over here https://github.com/tobscure/json-api/issues/51