### PR TITLE
add relationsships with dash in relationship name

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -77,7 +77,8 @@ abstract class AbstractSerializer implements SerializerInterface
      * 
      * @return string New function name
      */
-    private function replaceDashWithUppercase($name) {
+    private function replaceDashWithUppercase($name)
+    {
         return lcfirst(implode('', array_map('ucfirst', explode('-', $name))));
     }
 }

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -53,6 +53,10 @@ abstract class AbstractSerializer implements SerializerInterface
      */
     public function getRelationship($model, $name)
     {
+        if (stripos($name, '-')) {
+            $name = $this->replaceDashWithUppercase($name);
+        }
+
         if (method_exists($this, $name)) {
             $relationship = $this->$name($model);
 
@@ -63,5 +67,17 @@ abstract class AbstractSerializer implements SerializerInterface
 
             return $relationship;
         }
+    }
+
+    /**
+     * Removes all dashes from relationsship and uppercases the following letter.
+     * @example If relationship parent-page is needed the the function name will be changed to parentPage
+     * 
+     * @param string Name of the function
+     * 
+     * @return string New function name
+     */
+    private function replaceDashWithUppercase($name) {
+        return lcfirst(implode('', array_map('ucfirst', explode('-', $name))));
     }
 }


### PR DESCRIPTION
I wanted to add a relationsship with a dash ("-") in the relationship name. That was not possible because a function with a dash in function name cannot be called. Not the dash will be removed and a uppercase letter is appended.
Example:
"parent-page" will be changed to "parentPage"