### PR TITLE
Unification the API + a little bit improvements with tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [JSON-API](http://jsonapi.org) responses in PHP.
 
-Works with version 1.0 of the spec.
+Works with version 2.0 of the spec.
 
 ## Install
 
@@ -69,7 +69,7 @@ class PostSerializer extends AbstractSerializer
 {
     protected $type = 'posts';
 
-    protected function getAttributes($post, array $fields = [])
+    public function getAttributes($post, array $fields = [])
     {
         return [
             'title' => $post->title,
@@ -212,7 +212,7 @@ Feel free to send pull requests or create issues if you come across problems or 
 ### Running Tests
 
 ```bash
-$ phpunit
+$ ./vendor/bin/phpunit
 ```
 
 ## License

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -69,7 +69,7 @@ abstract class AbstractSerializer implements SerializerInterface
             $relationship = $this->$name($model);
 
             if ($relationship !== null && !($relationship instanceof Relationship)) {
-                throw new LogicException('Relationship method must return null or an instance of ' . Relationship::class);
+                throw new LogicException('Relationship method must return null or an instance of '.Relationship::class);
             }
 
             return $relationship;

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -68,7 +68,7 @@ abstract class AbstractSerializer implements SerializerInterface
         if (method_exists($this, $name)) {
             $relationship = $this->$name($model);
 
-            if ($relationship !== null && !($relationship instanceof Relationship)) {
+            if ($relationship !== null && ! ($relationship instanceof Relationship)) {
                 throw new LogicException('Relationship method must return null or an instance of '.Relationship::class);
             }
 

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -23,15 +23,20 @@ abstract class AbstractSerializer implements SerializerInterface
     protected $type;
 
     /**
-     * {@inheritdoc}
+     * Get the type.
+     *
+     * @return string
      */
-    public function getType($model)
+    public function getType()
     {
         return $this->type;
     }
 
     /**
-     * {@inheritdoc}
+     * Get the id.
+     *
+     * @param mixed $model
+     * @return string
      */
     public function getId($model)
     {
@@ -39,26 +44,32 @@ abstract class AbstractSerializer implements SerializerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Get the attributes array.
+     *
+     * @param mixed $model
+     * @param array $fields
+     * @return array
      */
-    public function getAttributes($model, array $fields = null)
+    public function getAttributes($model, array $fields = [])
     {
         return [];
     }
 
     /**
-     * {@inheritdoc}
+     * Get a relationship.
      *
+     * @param mixed $model
+     * @param string $name
      * @throws LogicException
+     * @return \Tobscure\JsonApi\Relationship|null
      */
     public function getRelationship($model, $name)
     {
         if (method_exists($this, $name)) {
             $relationship = $this->$name($model);
 
-            if ($relationship !== null && ! ($relationship instanceof Relationship)) {
-                throw new LogicException('Relationship method must return null or an instance of '
-                    .Relationship::class);
+            if ($relationship !== null && !($relationship instanceof Relationship)) {
+                throw new LogicException('Relationship method must return null or an instance of ' . Relationship::class);
             }
 
             return $relationship;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -41,7 +41,7 @@ class Collection implements ElementInterface
         $resources = [];
 
         foreach ($data as $resource) {
-            if (!($resource instanceof Resource)) {
+            if (! ($resource instanceof Resource)) {
                 $resource = new Resource($resource, $serializer);
             }
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -41,7 +41,7 @@ class Collection implements ElementInterface
         $resources = [];
 
         foreach ($data as $resource) {
-            if (! ($resource instanceof Resource)) {
+            if (!($resource instanceof Resource)) {
                 $resource = new Resource($resource, $serializer);
             }
 
@@ -52,7 +52,9 @@ class Collection implements ElementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Get the resources array.
+     *
+     * @return array
      */
     public function getResources()
     {
@@ -115,7 +117,9 @@ class Collection implements ElementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Map to a "resource object" array.
+     *
+     * @return array
      */
     public function toArray()
     {
@@ -125,7 +129,9 @@ class Collection implements ElementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Map to a "resource object identifier" array.
+     *
+     * @return array
      */
     public function toIdentifier()
     {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -43,7 +43,7 @@ class Resource implements ElementInterface
     /**
      * An array of Resources that should be merged into this one.
      *
-     * @var Resource[]
+     * @var self[]
      */
     protected $merged = [];
 
@@ -122,7 +122,7 @@ class Resource implements ElementInterface
      */
     public function getType()
     {
-        return $this->serializer->getType($this->data);
+        return $this->serializer->getType();
     }
 
     /**
@@ -158,7 +158,7 @@ class Resource implements ElementInterface
     /**
      * Get the requested fields for this resource type.
      *
-     * @return array|null
+     * @return array
      */
     protected function getOwnFields()
     {
@@ -167,6 +167,8 @@ class Resource implements ElementInterface
         if (isset($this->fields[$type])) {
             return $this->fields[$type];
         }
+
+        return [];
     }
 
     /**

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -16,10 +16,9 @@ interface SerializerInterface
     /**
      * Get the type.
      *
-     * @param mixed $model
      * @return string
      */
-    public function getType($model);
+    public function getType();
 
     /**
      * Get the id.
@@ -33,10 +32,10 @@ interface SerializerInterface
      * Get the attributes array.
      *
      * @param mixed $model
-     * @param array|null $fields
+     * @param array $fields
      * @return array
      */
-    public function getAttributes($model, array $fields = null);
+    public function getAttributes($model, array $fields = []);
 
     /**
      * Get a relationship.

--- a/tests/AbstractSerializerTest.php
+++ b/tests/AbstractSerializerTest.php
@@ -11,22 +11,21 @@
 
 namespace Tobscure\Tests\JsonApi;
 
-use Tobscure\JsonApi\AbstractSerializer;
-use Tobscure\JsonApi\Collection;
 use Tobscure\JsonApi\Relationship;
+use Tobscure\Tests\JsonApi\stubs\SerializerTestPostSerializer;
 
 class AbstractSerializerTest extends AbstractTestCase
 {
     public function testGetTypeReturnsTheType()
     {
-        $serializer = new PostSerializer1;
+        $serializer = new SerializerTestPostSerializer();
 
-        $this->assertEquals('posts', $serializer->getType(null));
+        $this->assertEquals('posts', $serializer->getType());
     }
 
     public function testGetAttributesReturnsTheAttributes()
     {
-        $serializer = new PostSerializer1;
+        $serializer = new SerializerTestPostSerializer();
         $post = (object) ['foo' => 'bar'];
 
         $this->assertEquals(['foo' => 'bar'], $serializer->getAttributes($post));
@@ -34,7 +33,7 @@ class AbstractSerializerTest extends AbstractTestCase
 
     public function testGetRelationshipReturnsRelationshipFromMethod()
     {
-        $serializer = new PostSerializer1;
+        $serializer = new SerializerTestPostSerializer();
 
         $relationship = $serializer->getRelationship(null, 'comments');
 
@@ -46,30 +45,8 @@ class AbstractSerializerTest extends AbstractTestCase
      */
     public function testGetRelationshipValidatesRelationship()
     {
-        $serializer = new PostSerializer1;
+        $serializer = new SerializerTestPostSerializer();
 
         $serializer->getRelationship(null, 'invalid');
-    }
-}
-
-class PostSerializer1 extends AbstractSerializer
-{
-    protected $type = 'posts';
-
-    public function getAttributes($post, array $fields = null)
-    {
-        return ['foo' => $post->foo];
-    }
-
-    public function comments($post)
-    {
-        $element = new Collection([], new self);
-
-        return new Relationship($element);
-    }
-
-    public function invalid($post)
-    {
-        return 'invalid';
     }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -11,10 +11,10 @@
 
 namespace Tobscure\Tests\JsonApi\Element;
 
-use Tobscure\JsonApi\AbstractSerializer;
 use Tobscure\JsonApi\Collection;
 use Tobscure\JsonApi\Resource;
 use Tobscure\Tests\JsonApi\AbstractTestCase;
+use Tobscure\Tests\JsonApi\stubs\CollectionTestPostSerializer;
 
 /**
  * This is the collection test class.
@@ -25,7 +25,7 @@ class CollectionTest extends AbstractTestCase
 {
     public function testToArrayReturnsArrayOfResources()
     {
-        $serializer = new PostSerializer3;
+        $serializer = new CollectionTestPostSerializer();
 
         $post1 = (object) ['id' => 1, 'foo' => 'bar'];
         $post2 = new Resource((object) ['id' => 2, 'foo' => 'baz'], $serializer);
@@ -40,7 +40,7 @@ class CollectionTest extends AbstractTestCase
 
     public function testToIdentifierReturnsArrayOfResourceIdentifiers()
     {
-        $serializer = new PostSerializer3;
+        $serializer = new CollectionTestPostSerializer();
 
         $post1 = (object) ['id' => 1];
         $post2 = (object) ['id' => 2];
@@ -51,15 +51,5 @@ class CollectionTest extends AbstractTestCase
         $resource2 = new Resource($post2, $serializer);
 
         $this->assertEquals([$resource1->toIdentifier(), $resource2->toIdentifier()], $collection->toIdentifier());
-    }
-}
-
-class PostSerializer3 extends AbstractSerializer
-{
-    protected $type = 'posts';
-
-    public function getAttributes($post, array $fields = null)
-    {
-        return ['foo' => $post->foo];
     }
 }

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -11,7 +11,6 @@
 
 namespace Tobscure\Tests\JsonApi;
 
-use Tobscure\JsonApi\AbstractSerializer;
 use Tobscure\JsonApi\Document;
 use Tobscure\JsonApi\Resource;
 use Tobscure\Tests\JsonApi\stubs\DocumentTestPostSerializer;

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -14,6 +14,7 @@ namespace Tobscure\Tests\JsonApi;
 use Tobscure\JsonApi\AbstractSerializer;
 use Tobscure\JsonApi\Document;
 use Tobscure\JsonApi\Resource;
+use Tobscure\Tests\JsonApi\stubs\DocumentTestPostSerializer;
 
 /**
  * This is the document test class.
@@ -29,8 +30,7 @@ class DocumentTest extends AbstractTestCase
             'foo' => 'bar'
         ];
 
-        $resource = new Resource($post, new PostSerializer2);
-
+        $resource = new Resource($post, new DocumentTestPostSerializer());
         $document = new Document($resource);
 
         $this->assertEquals(['data' => $resource->toArray()], $document->toArray());
@@ -39,15 +39,5 @@ class DocumentTest extends AbstractTestCase
     public function testItCanBeSerializedToJson()
     {
         $this->assertEquals('[]', (string) new Document());
-    }
-}
-
-class PostSerializer2 extends AbstractSerializer
-{
-    protected $type = 'posts';
-
-    public function getAttributes($post, array $fields = null)
-    {
-        return ['foo' => $post->foo];
     }
 }

--- a/tests/LinksTraitTest.php
+++ b/tests/LinksTraitTest.php
@@ -11,7 +11,7 @@
 
 namespace Tobscure\Tests\JsonApi;
 
-use Tobscure\JsonApi\LinksTrait;
+use Tobscure\Tests\JsonApi\stubs\LinksTraitDocument;
 
 /**
  * This is the document test class.
@@ -22,7 +22,7 @@ class LinksTraitTest extends AbstractTestCase
 {
     public function testAddPaginationLinks()
     {
-        $document = new Document;
+        $document = new LinksTraitDocument();
         $document->addPaginationLinks('http://example.org', [], 0, 20);
 
         $this->assertEquals([
@@ -30,7 +30,7 @@ class LinksTraitTest extends AbstractTestCase
             'next' => 'http://example.org?page%5Boffset%5D=20'
         ], $document->getLinks());
 
-        $document = new Document;
+        $document = new LinksTraitDocument();
         $document->addPaginationLinks('http://example.org', ['foo' => 'bar', 'page' => ['limit' => 20]], 30, 20, 100);
 
         $this->assertEquals([
@@ -40,7 +40,7 @@ class LinksTraitTest extends AbstractTestCase
             'last' => 'http://example.org?foo=bar&page%5Blimit%5D=20&page%5Boffset%5D=80'
         ], $document->getLinks());
 
-        $document = new Document;
+        $document = new LinksTraitDocument();
         $document->addPaginationLinks('http://example.org', ['page' => ['number' => 2]], 50, 20, 100);
 
         $this->assertEquals([
@@ -50,9 +50,4 @@ class LinksTraitTest extends AbstractTestCase
             'last' => 'http://example.org?page%5Bnumber%5D=5'
         ], $document->getLinks());
     }
-}
-
-class Document
-{
-    use LinksTrait;
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -11,11 +11,9 @@
 
 namespace Tobscure\Tests\JsonApi\Element;
 
-use Tobscure\JsonApi\AbstractSerializer;
-use Tobscure\JsonApi\Collection;
-use Tobscure\JsonApi\Relationship;
 use Tobscure\JsonApi\Resource;
 use Tobscure\Tests\JsonApi\AbstractTestCase;
+use Tobscure\Tests\JsonApi\stubs\ResourceTestPostSerializer;
 
 class ResourceTest extends AbstractTestCase
 {
@@ -23,7 +21,7 @@ class ResourceTest extends AbstractTestCase
     {
         $data = (object) ['id' => '123', 'foo' => 'bar', 'baz' => 'qux'];
 
-        $resource = new Resource($data, new PostSerializer4);
+        $resource = new Resource($data, new ResourceTestPostSerializer());
 
         $this->assertEquals([
             'type' => 'posts',
@@ -39,7 +37,7 @@ class ResourceTest extends AbstractTestCase
     {
         $data = (object) ['id' => '123', 'foo' => 'bar'];
 
-        $resource = new Resource($data, new PostSerializer4);
+        $resource = new Resource($data, new ResourceTestPostSerializer());
 
         $this->assertEquals([
             'type' => 'posts',
@@ -59,14 +57,14 @@ class ResourceTest extends AbstractTestCase
     {
         $data = (object) ['id' => 123];
 
-        $resource = new Resource($data, new PostSerializer4);
+        $resource = new Resource($data, new ResourceTestPostSerializer());
 
         $this->assertSame('123', $resource->getId());
     }
 
     public function testGetIdWorksWithScalarData()
     {
-        $resource = new Resource(123, new PostSerializer4);
+        $resource = new Resource(123, new ResourceTestPostSerializer());
 
         $this->assertSame('123', $resource->getId());
     }
@@ -75,7 +73,7 @@ class ResourceTest extends AbstractTestCase
     {
         $data = (object) ['id' => '123', 'foo' => 'bar', 'baz' => 'qux'];
 
-        $resource = new Resource($data, new PostSerializer4);
+        $resource = new Resource($data, new ResourceTestPostSerializer());
 
         $resource->fields(['posts' => ['baz']]);
 
@@ -93,8 +91,8 @@ class ResourceTest extends AbstractTestCase
         $post1 = (object) ['id' => '123', 'foo' => 'bar', 'comments' => [1]];
         $post2 = (object) ['id' => '123', 'baz' => 'qux', 'comments' => [1, 2]];
 
-        $resource1 = new Resource($post1, new PostSerializer4);
-        $resource2 = new Resource($post2, new PostSerializer4);
+        $resource1 = new Resource($post1, new ResourceTestPostSerializer());
+        $resource2 = new Resource($post2, new ResourceTestPostSerializer());
 
         $resource1->with(['comments']);
         $resource2->with(['comments']);
@@ -118,33 +116,4 @@ class ResourceTest extends AbstractTestCase
             ]
         ], $resource1->toArray());
     }
-}
-
-class PostSerializer4 extends AbstractSerializer
-{
-    protected $type = 'posts';
-
-    public function getAttributes($post, array $fields = null)
-    {
-        $attributes = [];
-
-        if (isset($post->foo)) {
-            $attributes['foo'] = $post->foo;
-        }
-        if (isset($post->baz)) {
-            $attributes['baz'] = $post->baz;
-        }
-
-        return $attributes;
-    }
-
-    public function comments($post)
-    {
-        return new Relationship(new Collection($post->comments, new CommentSerializer));
-    }
-}
-
-class CommentSerializer extends AbstractSerializer
-{
-    protected $type = 'comments';
 }

--- a/tests/stubs/CollectionTestPostSerializer.php
+++ b/tests/stubs/CollectionTestPostSerializer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tobscure\Tests\JsonApi\stubs;
+
+use Tobscure\JsonApi\AbstractSerializer;
+
+class CollectionTestPostSerializer extends AbstractSerializer
+{
+    protected $type = 'posts';
+
+    public function getAttributes($post, array $fields = [])
+    {
+        return [
+            'foo' => $post->foo
+        ];
+    }
+}

--- a/tests/stubs/DocumentTestPostSerializer.php
+++ b/tests/stubs/DocumentTestPostSerializer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tobscure\Tests\JsonApi\stubs;
+
+use Tobscure\JsonApi\AbstractSerializer;
+
+class DocumentTestPostSerializer extends AbstractSerializer
+{
+    protected $type = 'posts';
+
+    public function getAttributes($post, array $fields = [])
+    {
+        return [
+            'foo' => $post->foo
+        ];
+    }
+}

--- a/tests/stubs/LinksTraitDocument.php
+++ b/tests/stubs/LinksTraitDocument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tobscure\Tests\JsonApi\stubs;
+
+use Tobscure\JsonApi\LinksTrait;
+
+class LinksTraitDocument
+{
+    use LinksTrait;
+}

--- a/tests/stubs/ResourceTestCommentSerializer.php
+++ b/tests/stubs/ResourceTestCommentSerializer.php
@@ -8,4 +8,3 @@ class ResourceTestCommentSerializer extends AbstractSerializer
 {
     protected $type = 'comments';
 }
-

--- a/tests/stubs/ResourceTestCommentSerializer.php
+++ b/tests/stubs/ResourceTestCommentSerializer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tobscure\Tests\JsonApi\stubs;
+
+use Tobscure\JsonApi\AbstractSerializer;
+
+class ResourceTestCommentSerializer extends AbstractSerializer
+{
+    protected $type = 'comments';
+}
+

--- a/tests/stubs/ResourceTestPostSerializer.php
+++ b/tests/stubs/ResourceTestPostSerializer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tobscure\Tests\JsonApi\stubs;
+
+use Tobscure\JsonApi\AbstractSerializer;
+use Tobscure\JsonApi\Collection;
+use Tobscure\JsonApi\Relationship;
+
+class ResourceTestPostSerializer extends AbstractSerializer
+{
+    protected $type = 'posts';
+
+    public function getAttributes($post, array $fields = [])
+    {
+        $attributes = [];
+
+        if (isset($post->foo)) {
+            $attributes['foo'] = $post->foo;
+        }
+        if (isset($post->baz)) {
+            $attributes['baz'] = $post->baz;
+        }
+
+        return $attributes;
+    }
+
+    public function comments($post)
+    {
+        return new Relationship(
+            new Collection($post->comments, new ResourceTestCommentSerializer())
+        );
+    }
+}

--- a/tests/stubs/SerializerTestCommentSerializer.php
+++ b/tests/stubs/SerializerTestCommentSerializer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tobscure\Tests\JsonApi\stubs;
+
+use Tobscure\JsonApi\AbstractSerializer;
+
+class SerializerTestCommentSerializer extends AbstractSerializer
+{
+    protected $type = 'comments';
+}
+

--- a/tests/stubs/SerializerTestCommentSerializer.php
+++ b/tests/stubs/SerializerTestCommentSerializer.php
@@ -8,4 +8,3 @@ class SerializerTestCommentSerializer extends AbstractSerializer
 {
     protected $type = 'comments';
 }
-

--- a/tests/stubs/SerializerTestPostSerializer.php
+++ b/tests/stubs/SerializerTestPostSerializer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tobscure\Tests\JsonApi\stubs;
+
+use Tobscure\JsonApi\AbstractSerializer;
+use Tobscure\JsonApi\Collection;
+use Tobscure\JsonApi\Relationship;
+
+class SerializerTestPostSerializer extends AbstractSerializer
+{
+    protected $type = 'posts';
+
+    public function getAttributes($post, array $fields = [])
+    {
+        return [
+            'foo' => $post->foo
+        ];
+    }
+
+    public function comments($post)
+    {
+        $element = new Collection([], new SerializerTestCommentSerializer());
+
+        return new Relationship($element);
+    }
+
+    public function invalid($post)
+    {
+        return 'invalid';
+    }
+}


### PR DESCRIPTION
Hi,

My changes will break down the API compatibility. 

In my opinion, classes which are necessary only for tests should be defined in dedicated (`stubs`) namespace. I've done it. All classes from test scenarios have been moved to `tests/stubs` directory.

Another change what I've done is change in the interface (API). In my opinion the method `SerializerInterface::getAttributes()` should be called with some `$model` and some `$fields`, but the `$fields` parameter should always be an array. The next one change is method `getType()` in the same Interface. I've removed unused parameter `$model`. 

Additionally I've fixed phpDoc in some classes, nothing special :)

I'm open on your opinion. If is anything what I could improvement, tell me.
