### PR TITLE
Fixed "sorting oldest does not work" in flarum

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -125,12 +125,13 @@ class Parameters
 
             foreach ($fields as $field) {
                 if (substr($field, 0, 1) === '-') {
-                    $field = substr($field, 1);
                     $order = 'desc';
                 } else {
                     $order = 'asc';
                 }
-
+                
+                $field = substr($field, 1);
+                
                 $sort[$field] = $order;
             }
 


### PR DESCRIPTION
This PR fixed https://github.com/flarum/core/issues/627
In flarum,we use "+startTime" parameters to represent discussions sorting by oldest.But in tobscure/json-api we can't correctly understand it.If the parameter don't have "-",we can't get the $field.So this PR fixed this problem.