### PR TITLE
Parameters' `getLimit` returns integer or null

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -96,13 +96,13 @@ class Parameters
      * Get the limit.
      *
      * @param int|null $max
-     * @return string
+     * @return int|null
      */
     public function getLimit($max = null)
     {
-        $limit = $this->getPage('limit') ?: $this->getPage('size');
+        $limit = $this->getPage('limit') ?: $this->getPage('size') ?: null;
 
-        if ($max) {
+        if ($limit && $max) {
             $limit = min($max, $limit);
         }
 

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -86,6 +86,13 @@ class ParametersTest extends AbstractTestCase
         $this->assertEquals(100, $parameters->getLimit());
     }
 
+    public function testGetLimitReturnsNullWhenNotSet()
+    {
+        $parameters = new Parameters(['page' => ['offset' => 50]]);
+
+        $this->assertNull($parameters->getLimit());
+    }
+
     public function testGetFieldsReturnsAllFields()
     {
         $parameters = new Parameters(['fields' => ['posts' => 'title,content', 'users' => 'name']]);


### PR DESCRIPTION
As discussed in issue #71.


