### PR TITLE
Updated Readme as passing $fields = [] to getAttributes throws error

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class PostSerializer extends AbstractSerializer
 {
     protected $type = 'posts';
 
-    public function getAttributes($post, array $fields = [])
+    public function getAttributes($post, array $fields = null)
     {
         return [
             'title' => $post->title,


### PR DESCRIPTION
This error is thrown with $field = []:
```
Catchable Fatal Error: Argument 2 passed to AppBundle\Serializer\PageCategorySerializer::getAttributes() must be of the type array, null given, called in /home/vagrant/source/vendor/tobscure/json-api/src/Resource.php on line 149 and defined
```
PHP 5.6