### PR TITLE
Removed "::class" for PHP 5.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0"

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -61,8 +61,7 @@ abstract class AbstractSerializer implements SerializerInterface
             $relationship = $this->$name($model);
 
             if ($relationship !== null && ! ($relationship instanceof Relationship)) {
-                throw new LogicException('Relationship method must return null or an instance of '
-                    .Relationship::class);
+                throw new LogicException('Relationship method must return null or an instance of Relationship');
             }
 
             return $relationship;


### PR DESCRIPTION
This small change makes json-api compatible with PHP 5.4. 
See issue #77.