### PR TITLE
Allow serializers to add links

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $document->setMeta(['key' => 'value']);
 They also allow you to add links in a similar way:
 
 ```php
-$resource = new Resource;
+$resource = new Resource($data, $serializer);
 $resource->addLink('self', 'url');
 $resource->setLinks(['key' => 'value']);
 ```
@@ -131,6 +131,19 @@ $document->addPaginationLinks(
     100    // The total number of results
 );
 ```
+Serializers can provide links as well:
+
+```php
+use Tobscure\JsonApi\AbstractSerializer;
+
+class PostSerializer extends AbstractSerializer
+{
+    // ...
+    
+    public function getLinks($post) {
+        return ['self' => '/posts/' . $post->id];
+    }
+}
 
 ### Parameters
 

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -48,6 +48,14 @@ abstract class AbstractSerializer implements SerializerInterface
 
     /**
      * {@inheritdoc}
+     */
+    public function getLinks($model)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @throws LogicException
      */
@@ -72,9 +80,9 @@ abstract class AbstractSerializer implements SerializerInterface
     /**
      * Removes all dashes from relationsship and uppercases the following letter.
      * @example If relationship parent-page is needed the the function name will be changed to parentPage
-     * 
+     *
      * @param string Name of the function
-     * 
+     *
      * @return string New function name
      */
     private function replaceDashWithUppercase($name)

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -80,8 +80,16 @@ class Resource implements ElementInterface
             $array['relationships'] = $relationships;
         }
 
+        $links = [];
         if (! empty($this->links)) {
-            $array['links'] = $this->links;
+            $links = $this->links;
+        }
+        $serializerLinks = $this->serializer->getLinks($this->data);
+        if (! empty($serializerLinks)) {
+            $links = array_merge($serializerLinks, $links);
+        }
+        if (! empty($links)) {
+            $array['links'] = $links;
         }
 
         return $array;

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -39,6 +39,14 @@ interface SerializerInterface
     public function getAttributes($model, array $fields = null);
 
     /**
+     * Get the links array.
+     *
+     * @param mixed $model
+     * @return array
+     */
+    public function getLinks($model);
+
+    /**
      * Get a relationship.
      *
      * @param mixed $model


### PR DESCRIPTION
With this change Serializers can provide links like::

```
class PostSerializer implements SerializerInterface
{
    // ...

    public function getLinks($post) {
        return ['self' => '/posts/' . $post->id];
    }
}
```

Partly resolves #64