### PR TITLE
Make $model for getType() optional

### DIFF
--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -19,7 +19,7 @@ interface SerializerInterface
      * @param mixed $model
      * @return string
      */
-    public function getType($model);
+    public function getType($model = null);
 
     /**
      * Get the id.


### PR DESCRIPTION
Most often the serializer knows about the type, a `$model` would just be a stub here