### PR TITLE
Allow serializers to add metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $document->addPaginationLinks(
     100    // The total number of results
 );
 ```
-Serializers can provide links as well:
+Serializers can provide links and/or meta data as well:
 
 ```php
 use Tobscure\JsonApi\AbstractSerializer;
@@ -143,7 +143,13 @@ class PostSerializer extends AbstractSerializer
     public function getLinks($post) {
         return ['self' => '/posts/' . $post->id];
     }
+
+    public function getMeta() {
+        return ['some' => 'metadata'];
+    }
 }
+
+**Note:** Links and metadata of the resource overrule ones with the same key from the serializer!
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ class PostSerializer extends AbstractSerializer
         return ['self' => '/posts/' . $post->id];
     }
 
-    public function getMeta() {
-        return ['some' => 'metadata'];
+    public function getMeta($post) {
+        return ['some' => 'metadata for ' . $post->id];
     }
 }
 

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -57,7 +57,7 @@ abstract class AbstractSerializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function getMeta()
+    public function getMeta($model)
     {
         return [];
     }

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -56,6 +56,14 @@ abstract class AbstractSerializer implements SerializerInterface
 
     /**
      * {@inheritdoc}
+     */
+    public function getMeta()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @throws LogicException
      */

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -92,6 +92,18 @@ class Resource implements ElementInterface
             $array['links'] = $links;
         }
 
+        $meta = [];
+        if (! empty($this->meta)) {
+            $meta = $this->meta;
+        }
+        $serializerMeta = $this->serializer->getMeta();
+        if (! empty($serializerMeta)) {
+            $meta = array_merge($serializerMeta, $meta);
+        }
+        if (! empty($meta)) {
+            $array['meta'] = $meta;
+        }
+
         return $array;
     }
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -96,7 +96,7 @@ class Resource implements ElementInterface
         if (! empty($this->meta)) {
             $meta = $this->meta;
         }
-        $serializerMeta = $this->serializer->getMeta();
+        $serializerMeta = $this->serializer->getMeta($this->data);
         if (! empty($serializerMeta)) {
             $meta = array_merge($serializerMeta, $meta);
         }

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -47,6 +47,13 @@ interface SerializerInterface
     public function getLinks($model);
 
     /**
+     * Get the meta.
+     *
+     * @return array
+     */
+    public function getMeta();
+
+    /**
      * Get a relationship.
      *
      * @param mixed $model

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -49,9 +49,10 @@ interface SerializerInterface
     /**
      * Get the meta.
      *
+     * @param mixed $model
      * @return array
      */
-    public function getMeta();
+    public function getMeta($model);
 
     /**
      * Get a relationship.

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -36,7 +36,7 @@ class ResourceTest extends AbstractTestCase
                 'self' => '/posts/123'
             ],
             'meta' => [
-                'some-meta' => 'from-serializer'
+                'some-meta' => 'from-serializer-for-123'
             ]
         ], $resource->toArray());
     }
@@ -144,7 +144,7 @@ class ResourceTest extends AbstractTestCase
                 'related' => '/some/other/comment'
             ],
             'meta' => [
-                'some-meta' => 'from-serializer'
+                'some-meta' => 'from-serializer-for-123'
             ]
         ], $resource1->toArray());
     }
@@ -202,9 +202,9 @@ class PostSerializer4WithLinksAndMeta extends PostSerializer4
         return ['self' => sprintf('/posts/%s', $post->id)];
     }
 
-    public function getMeta()
+    public function getMeta($post)
     {
-        return ['some-meta' => 'from-serializer'];
+        return ['some-meta' => sprintf('from-serializer-for-%s', $post->id)];
     }
 }
 


### PR DESCRIPTION
With this change Serializers can provide metadata like::

```
class PostSerializer implements SerializerInterface
{
    // ...

    public function getMeta() {
        return ['some' => 'metadata'];
    }
}
```

Resolves #64