### PR TITLE
Update php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": "^5.5.9 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0"


### PR DESCRIPTION
We wont know if the package will break in the future. This way we can get ahead by allowing specific versions of PHP.