### PR TITLE
Enhance invalid parameter exceptions

### DIFF
--- a/src/Exception/Handler/InvalidParameterExceptionHandler.php
+++ b/src/Exception/Handler/InvalidParameterExceptionHandler.php
@@ -37,6 +37,11 @@ class InvalidParameterExceptionHandler implements ExceptionHandlerInterface
             $error['code'] = $code;
         }
 
+        $invalidParameter = $e->getInvalidParameter();
+        if ($invalidParameter) {
+            $error['source'] = ['parameter' => $invalidParameter];
+        }
+
         return new ResponseBag($status, [$error]);
     }
 }

--- a/src/Exception/Handler/InvalidParameterExceptionHandler.php
+++ b/src/Exception/Handler/InvalidParameterExceptionHandler.php
@@ -32,6 +32,11 @@ class InvalidParameterExceptionHandler implements ExceptionHandlerInterface
         $status = 400;
         $error = [];
 
+        $code = $e->getCode();
+        if ($code) {
+            $error['code'] = $code;
+        }
+
         return new ResponseBag($status, [$error]);
     }
 }

--- a/src/Exception/InvalidParameterException.php
+++ b/src/Exception/InvalidParameterException.php
@@ -15,4 +15,28 @@ use Exception;
 
 class InvalidParameterException extends Exception
 {
+    /**
+     * @var string The parameter that caused this exception.
+     */
+    private $invalidParameter;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $invalidParameter The parameter that caused this exception.
+     */
+    public function __construct($message = '', $code = 0, $previous = null, $invalidParameter = '')
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->invalidParameter = $invalidParameter;
+    }
+
+    /**
+     * @return string The parameter that caused this exception.
+     */
+    public function getInvalidParameter()
+    {
+        return $this->invalidParameter;
+    }
 }

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -43,7 +43,7 @@ class Parameters
             $invalid = array_diff($relationships, $available);
 
             if (count($invalid)) {
-                throw new InvalidParameterException('Invalid includes ['.implode(',', $invalid).']');
+                throw new InvalidParameterException('Invalid includes ['.implode(',', $invalid).']', 1);
             }
 
             return $relationships;
@@ -68,7 +68,7 @@ class Parameters
         $offset = (int) $this->getPage('offset');
 
         if ($offset < 0) {
-            throw new InvalidParameterException('page[offset] must be >=0');
+            throw new InvalidParameterException('page[offset] must be >=0', 2);
         }
 
         return $offset;
@@ -136,7 +136,7 @@ class Parameters
             $invalid = array_diff(array_keys($sort), $available);
 
             if (count($invalid)) {
-                throw new InvalidParameterException('Invalid sort fields ['.implode(',', $invalid).']');
+                throw new InvalidParameterException('Invalid sort fields ['.implode(',', $invalid).']', 3);
             }
         }
 

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -43,7 +43,12 @@ class Parameters
             $invalid = array_diff($relationships, $available);
 
             if (count($invalid)) {
-                throw new InvalidParameterException('Invalid includes ['.implode(',', $invalid).']', 1);
+                throw new InvalidParameterException(
+                    'Invalid includes ['.implode(',', $invalid).']',
+                    1,
+                    null,
+                    'include'
+                );
             }
 
             return $relationships;
@@ -68,7 +73,7 @@ class Parameters
         $offset = (int) $this->getPage('offset');
 
         if ($offset < 0) {
-            throw new InvalidParameterException('page[offset] must be >=0', 2);
+            throw new InvalidParameterException('page[offset] must be >=0', 2, null, 'page[offset]');
         }
 
         return $offset;
@@ -136,7 +141,12 @@ class Parameters
             $invalid = array_diff(array_keys($sort), $available);
 
             if (count($invalid)) {
-                throw new InvalidParameterException('Invalid sort fields ['.implode(',', $invalid).']', 3);
+                throw new InvalidParameterException(
+                    'Invalid sort fields ['.implode(',', $invalid).']',
+                    3,
+                    null,
+                    'sort'
+                );
             }
         }
 

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -79,7 +79,6 @@ class Parameters
      *
      * @param int $perPage
      * @return int
-     * @throws InvalidParameterException
      */
     protected function getOffsetFromNumber($perPage)
     {

--- a/tests/Exception/Handler/InvalidParameterExceptionHandlerTest.php
+++ b/tests/Exception/Handler/InvalidParameterExceptionHandlerTest.php
@@ -35,10 +35,10 @@ class InvalidParameterExceptionHandlerTest extends \PHPUnit_Framework_TestCase
     public function testErrorHandling()
     {
         $handler = new InvalidParameterExceptionHandler();
-        $response = $handler->handle(new InvalidParameterException('error', 1));
+        $response = $handler->handle(new InvalidParameterException('error', 1, null, 'include'));
 
         $this->assertInstanceOf(ResponseBag::class, $response);
         $this->assertEquals(400, $response->getStatus());
-        $this->assertEquals([['code' => 1]], $response->getErrors());
+        $this->assertEquals([['code' => 1, 'source' => ['parameter' => 'include']]], $response->getErrors());
     }
 }

--- a/tests/Exception/Handler/InvalidParameterExceptionHandlerTest.php
+++ b/tests/Exception/Handler/InvalidParameterExceptionHandlerTest.php
@@ -35,10 +35,10 @@ class InvalidParameterExceptionHandlerTest extends \PHPUnit_Framework_TestCase
     public function testErrorHandling()
     {
         $handler = new InvalidParameterExceptionHandler();
-        $response = $handler->handle(new InvalidParameterException('error'));
+        $response = $handler->handle(new InvalidParameterException('error', 1));
 
         $this->assertInstanceOf(ResponseBag::class, $response);
         $this->assertEquals(400, $response->getStatus());
-        $this->assertEquals([[]], $response->getErrors());
+        $this->assertEquals([['code' => 1]], $response->getErrors());
     }
 }

--- a/tests/Exception/Handler/InvalidParameterExceptionHandlerTest.php
+++ b/tests/Exception/Handler/InvalidParameterExceptionHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of JSON-API.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tobscure\Tests\Exception\Handler;
+
+use Exception;
+use Tobscure\JsonApi\Exception\Handler\InvalidParameterExceptionHandler;
+use Tobscure\JsonApi\Exception\Handler\ResponseBag;
+use Tobscure\JsonApi\Exception\InvalidParameterException;
+
+class InvalidParameterExceptionHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandlerCanManageInvalidParameterExceptions()
+    {
+        $handler = new InvalidParameterExceptionHandler();
+
+        $this->assertTrue($handler->manages(new InvalidParameterException));
+    }
+
+    public function testHandlerCanNotManageOtherExceptions()
+    {
+        $handler = new InvalidParameterExceptionHandler();
+
+        $this->assertFalse($handler->manages(new Exception));
+    }
+
+    public function testErrorHandling()
+    {
+        $handler = new InvalidParameterExceptionHandler();
+        $response = $handler->handle(new InvalidParameterException('error'));
+
+        $this->assertInstanceOf(ResponseBag::class, $response);
+        $this->assertEquals(400, $response->getStatus());
+        $this->assertEquals([[]], $response->getErrors());
+    }
+}

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -34,6 +34,16 @@ class ParametersTest extends AbstractTestCase
         $this->assertEquals([], $parameters->getInclude(['posts', 'images']));
     }
 
+    /**
+     * @expectedException \Tobscure\JsonApi\Exception\InvalidParameterException
+     */
+    public function testGetIncludeWithUnallowedField()
+    {
+        $parameters = new Parameters(['include' => 'posts,images']);
+
+        $parameters->getInclude(['posts']);
+    }
+
     public function testGetSortReturnsArrayOfFieldToSortDirection()
     {
         $parameters = new Parameters(['sort' => 'firstname']);
@@ -53,6 +63,16 @@ class ParametersTest extends AbstractTestCase
         $parameters = new Parameters([]);
 
         $this->assertEmpty($parameters->getSort());
+    }
+
+    /**
+     * @expectedException \Tobscure\JsonApi\Exception\InvalidParameterException
+     */
+    public function testGetSortWithUnallowedField()
+    {
+        $parameters = new Parameters(['sort' => 'firstname,lastname']);
+
+        $parameters->getSort(['firstname']);
     }
 
     public function testGetOffsetParsesThePageOffset()

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -36,6 +36,7 @@ class ParametersTest extends AbstractTestCase
 
     /**
      * @expectedException \Tobscure\JsonApi\Exception\InvalidParameterException
+     * @expectedExceptionCode 1
      */
     public function testGetIncludeWithUnallowedField()
     {
@@ -67,6 +68,7 @@ class ParametersTest extends AbstractTestCase
 
     /**
      * @expectedException \Tobscure\JsonApi\Exception\InvalidParameterException
+     * @expectedExceptionCode 3
      */
     public function testGetSortWithUnallowedField()
     {
@@ -84,6 +86,7 @@ class ParametersTest extends AbstractTestCase
 
     /**
      * @expectedException \Tobscure\JsonApi\Exception\InvalidParameterException
+     * @expectedExceptionCode 2
      */
     public function testGetOffsetIsAtLeastZero()
     {

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -69,7 +69,7 @@ class ParametersTest extends AbstractTestCase
     {
         $parameters = new Parameters(['page' => ['offset' => -5]]);
 
-        $this->assertEquals(0, $parameters->getOffset());
+        $parameters->getOffset();
     }
 
     public function testGetOffsetParsesThePageNumber()


### PR DESCRIPTION
This fixes a couple minor issues in documentation/tests, adds some additional tests related to `InvalidParameterException`s, and most importantly adds some new functionality to these exceptions.

A unique exception code is added to each of the thrown `InvalidParameterException`s in the `Parameters` class.  This code is returned in the JSON API `errors` response built by the `InvalidParameterExceptionHandler`.

Also, the "source" of the error is exposed when available by setting which parameter was invalid on the exception.

An example JSON API error response from the included exception handler before this change:
```json
{
  "errors": [
    {}
  ]
}
```

An example JSON API error response after this change:
```json
{
  "errors": [
    {
      "code": 1,
      "source": {"parameter": "include"}
    }
  ]
}
```

Thanks for this library!  It's been a joy to work with.