### PR TITLE
Fixed: resource-identifier objects included empty 'attributes' field

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -72,7 +72,9 @@ class Resource implements ElementInterface
     {
         $array = $this->toIdentifier();
 
-        $array['attributes'] = $this->getAttributes();
+        if (! $this->isIdentifier()) {
+            $array['attributes'] = $this->getAttributes();
+        }
 
         $relationships = $this->getRelationshipsAsArray();
 


### PR DESCRIPTION
Addresses issue https://github.com/tobscure/json-api/issues/98

