### PR TITLE
Make id optional

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -126,13 +126,13 @@ class Resource implements ElementInterface
         if (! $this->data) {
             return null;
         }
-        
+
         $array = [
             'type' => $this->getType()
         ];
-        
+
         if($this->getId()) {
-            $array['id'] = $this->getId();
+            $array['id'] = (string) $this->getId();
         }
 
         if (! empty($this->meta)) {
@@ -163,7 +163,7 @@ class Resource implements ElementInterface
             return (string) $this->data;
         }
 
-        return $this->serializer->getId($this->data) !== false ? (string) $this->serializer->getId($this->data) : false;
+        return $this->serializer->getId($this->data);
     }
 
     /**

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -128,9 +128,12 @@ class Resource implements ElementInterface
         }
         
         $array = [
-            'type' => $this->getType(),
-            'id' => $this->getId()
+            'type' => $this->getType()
         ];
+        
+        if($this->getId()) {
+            $array['id'] = $this->getId();
+        }
 
         if (! empty($this->meta)) {
             $array['meta'] = $this->meta;
@@ -160,7 +163,7 @@ class Resource implements ElementInterface
             return (string) $this->data;
         }
 
-        return (string) $this->serializer->getId($this->data);
+        return $this->serializer->getId($this->data) !== false ? (string) $this->serializer->getId($this->data) : false;
     }
 
     /**


### PR DESCRIPTION
Json response without an id is now possible. Simply return false on the getId method of a Resource's Serializer and no id will be returned.

Documents without an id are conform the JSON API v1.0 specification. For example, see: http://jsonapi.org/format/#crud-creating