### PR TITLE
Replace method_exists by is_callable to allow calling relations that …

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -71,7 +71,7 @@ abstract class AbstractSerializer implements SerializerInterface
     {
         $method = $this->getRelationshipMethodName($name);
 
-        if (method_exists($this, $method)) {
+        if (is_callable([$this, $method])) {
             $relationship = $this->$method($model);
 
             if ($relationship !== null && ! ($relationship instanceof Relationship)) {


### PR DESCRIPTION
…have been defined at runtime using __call method. This is usefull in a modularized scenario where modules define new relations on core serializers.

Signed-off-by: Clemens John <clemens.john@floh1111.de>