### PR TITLE
Omit empty attributes

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -78,7 +78,10 @@ class Resource implements ElementInterface
         $array = $this->toIdentifier();
 
         if (! $this->isIdentifier()) {
-            $array['attributes'] = $this->getAttributes();
+            $attributes = $this->getAttributes();
+            if ($attributes) {
+                $array['attributes'] = $this->getAttributes();
+            }
         }
 
         $relationships = $this->getRelationshipsAsArray();

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -60,6 +60,19 @@ class DocumentTest extends AbstractTestCase
             ]
         ], $document->toArray());
     }
+
+    public function testNoEmptyAttributes()
+    {
+        $post = (object) [
+            'id' => 1,
+        ];
+
+        $resource = new Resource($post, new PostSerializerEmptyAttributes2);
+
+        $document = new Document($resource);
+
+        $this->assertEquals('{"data":{"type":"posts","id":"1"}}', (string) $document, 'Attributes should be omitted');
+    }
 }
 
 class PostSerializer2 extends AbstractSerializer
@@ -74,6 +87,14 @@ class PostSerializer2 extends AbstractSerializer
     public function comments($post)
     {
         return new Relationship(new Collection($post->comments, new CommentSerializer2));
+    }
+}
+
+class PostSerializerEmptyAttributes2 extends PostSerializer2
+{
+    public function getAttributes($post, array $fields = null)
+    {
+        return [];
     }
 }
 


### PR DESCRIPTION
### Issue
According to [the standard](http://jsonapi.org/format/#document-resource-objects), the `attributes` member of the resource must be an object. If the attributes list is empty, json_encode treats it as an array, producing invalid output like this:
```json
{"data":{"type":"posts","id":"1","attributes":[]}}
```
This behavior breaks some clients which expect `attributes` to be an object, not an array. In the same time, `attributes` is an optional member.

### Proposed solution
Omit empty `attributes` in the resulting json.