### PR TITLE
Do not call getAttributes() twice

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -80,7 +80,7 @@ class Resource implements ElementInterface
         if (! $this->isIdentifier()) {
             $attributes = $this->getAttributes();
             if ($attributes) {
-                $array['attributes'] = $this->getAttributes();
+                $array['attributes'] = $attributes;
             }
         }
 


### PR DESCRIPTION
Fixing my overlook from the last time.