### PR TITLE
Used is_callable instead of method_exists

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -71,7 +71,7 @@ abstract class AbstractSerializer implements SerializerInterface
     {
         $method = $this->getRelationshipMethodName($name);
 
-        if (method_exists($this, $method)) {
+        if (is_callable([$this, $method])) {
             $relationship = $this->$method($model);
 
             if ($relationship !== null && ! ($relationship instanceof Relationship)) {


### PR DESCRIPTION
Since a Serializer class might use __call(..) to resolve relations it might be better to use is_callable([$this, $method]) instead of method_exists($this, $method).